### PR TITLE
Automatically get Youtube version from the ipa itself

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -11,11 +11,6 @@ on:
         default: ""
         required: true
         type: string
-      youtube_version:
-        description: "The version of YouTube"
-        default: ""
-        required: true
-        type: string
       ytliteplus_version:
         description: "The version of YTLitePlus"
         default: "3.0.1"
@@ -103,16 +98,13 @@ jobs:
       - name: Prepare YouTube iPA
         run: |
           wget "$YOUTUBE_URL" --no-verbose -O main/YouTube.ipa
-          echo -e "==> \033[1mYouTube v${{ inputs.youtube_version }} downloaded! \033[0m"
           unzip -q main/YouTube.ipa -d main/tmp
+          echo "YT_VERSION=$(grep -A 1 '<key>CFBundleVersion</key>' main/tmp/Payload/YouTube.app/Info.plist | grep '<string>' | awk -F'[><]' '{print $3}')" >> $GITHUB_ENV
           rm -rf main/tmp/Payload/YouTube.app/_CodeSignature/CodeResources
           rm -rf main/tmp/Payload/YouTube.app/PlugIns/*
           cp -R main/Extensions/*.appex main/tmp/Payload/YouTube.app/PlugIns
-          echo -e "==> \033[1mYouTube v${{ inputs.youtube_version }} unpacked! \033[0m"
-
         env:
           THEOS: ${{ github.workspace }}/theos
-          YOUTUBE_VERSION: ${{ inputs.youtube_version }}
           YOUTUBE_URL: ${{ inputs.decrypted_youtube_url }}
 
       - name: Fix Compiling & Build Package
@@ -123,16 +115,15 @@ jobs:
           cd ${{ github.workspace }}/main
           sed -i '' "12s#.*#BUNDLE_ID = ${{ env.BUNDLE_ID }}#g" Makefile
           sed -i '' "11s#.*#DISPLAY_NAME = ${{ env.APP_NAME }}#g" Makefile
-          sed -i '' "s/^PACKAGE_VERSION.*$/PACKAGE_VERSION = ${{ inputs.youtube_version }}-${{ inputs.ytliteplus_version }}/" Makefile
+          sed -i '' "s/^PACKAGE_VERSION.*$/PACKAGE_VERSION = ${{ env.YT_VERSION }}-${{ inputs.ytliteplus_version }}/" Makefile
           make package FINALPACKAGE=1
-          (mv "packages/$(ls -t packages | head -n1)" "packages/YTLitePlus_${{ env.YOUTUBE_VERSION }}_${{ env.ytliteplus_version }}.ipa")        
+          (mv "packages/$(ls -t packages | head -n1)" "packages/YTLitePlus_${{ env.YT_VERSION }}_${{ env.ytliteplus_version }}.ipa")        
           echo "package=$(ls -t packages | head -n1)" >>$GITHUB_OUTPUT
           echo -e "==> \033[1mSHASUM256: $(shasum -a 256 packages/*.ipa | cut -f1 -d' ')\033[0m"
           echo -e "==> \033[1mBundle ID: ${{ env.BUNDLE_ID }}\033[0m"
         env:
           THEOS: ${{ github.workspace }}/theos
           ytliteplus_version: ${{ inputs.ytliteplus_version }}
-          YOUTUBE_VERSION: ${{ inputs.youtube_version }}
           BUNDLE_ID: ${{ inputs.bundle_id }}
           APP_NAME: ${{ inputs.app_name }}
 
@@ -140,16 +131,15 @@ jobs:
         uses: actions/upload-artifact@v4.3.1
         env:
           ytliteplus_version: ${{ inputs.ytliteplus_version }}
-          YOUTUBE_VERSION: ${{ inputs.youtube_version }}
         with:
-          name: YTLitePlus_${{ env.YOUTUBE_VERSION }}_${{ env.ytliteplus_version }}
+          name: YTLitePlus_${{ env.YT_VERSION }}_${{ env.ytliteplus_version }}
           path: ${{ github.workspace }}/main/packages/${{ steps.build_package.outputs.package }}
           if-no-files-found: error
       
       - name: Prepare Release Notes
         run: |
           export TODAY=$(date '+%Y-%m-%d')
-          sed "s/%ytliteplus_version%/${{ inputs.ytliteplus_version }}/g; s/%youtube_version%/${{ inputs.youtube_version }}/g; s/%date%/$TODAY/g" \
+          sed "s/%ytliteplus_version%/${{ inputs.ytliteplus_version }}/g; s/%youtube_version%/${{ env.YT_VERSION }}/g; s/%date%/$TODAY/g" \
           main/.github/RELEASE_TEMPLATE/Release.md > ${{ github.workspace }}/release_notes.md
 
       - name: Create Release
@@ -158,11 +148,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ytliteplus_version: ${{ inputs.ytliteplus_version }}
-          YOUTUBE_VERSION: ${{ inputs.youtube_version }}
           DRAFT: ${{ inputs.create_release }}
         with:
-          tag_name: v${{ env.YOUTUBE_VERSION }}-${{ env.ytliteplus_version }}
-          name: v${{ env.YOUTUBE_VERSION }}-${{ env.ytliteplus_version }} - YTLitePlus
+          tag_name: v${{ env.YT_VERSION }}-${{ env.ytliteplus_version }}
+          name: v${{ env.YT_VERSION }}-${{ env.ytliteplus_version }} - YTLitePlus
           files: main/packages/*.ipa
           draft: ${{ env.DRAFT }}
           body_path: ${{ github.workspace }}/release_notes.md


### PR DESCRIPTION
Hello!

I finnaly figured out my unrelated issue to this PR! It seems that i had two seperate bugs which i'm not sure is ytliteplus or ytlite (definitly need to check with only ytlite if this is the case)

It seems that automatically disable subtitles in the player section of ytlite doesn't work if a video goes full screen automatically.
And if VP9 is turned on withoud proper entitlements it causes video's with multiple audio tracks (e.g. mr beast video's) to choose the second language of the list (in this case bulgarian or something between those lines). (Sounds more like a ytuhd thing but i also have to test that somehow seperatly to properly submit an issue on that).

ANYHOW! back to the PR!

I want to  make one day some sort of ios shortcut that triggers that workflow with only giving the ipa url as an input, but i saw the yt version needs to be supplied each time, i figured that info should be stored in the ipa itself and found it so!

So instead of specifying it manually, it now does so automatically!
Proof:
![image](https://github.com/YTLitePlus/YTLitePlus/assets/26381427/762264e3-bdb2-45db-b209-2c72a6fbf3cc)

I did this by checking this within the unpacked ipa file: main/tmp/Payload/YouTube.app/Info.plist (main/tmp/ is the location when using it in this workflow). From there the xml file has a key named CFBundleVersion and the string contains the value we ussually manually insert!

Do note the wiki needs to be slightly updated to reflect this change if you want to merge it, i did test this out and believe it's working as expected.