### PR TITLE
Add Disable Engagement Overlay

### DIFF
--- a/Source/Settings.xm
+++ b/Source/Settings.xm
@@ -138,6 +138,7 @@ static const NSInteger YTLiteSection = 789;
             BASIC_SWITCH(LOC(@"DISABLE_PULL_TO_FULLSCREEN_GESTURE"), LOC(@"DISABLE_PULL_TO_FULLSCREEN_GESTURE_DESC"), @"disablePullToFull_enabled"),
             BASIC_SWITCH(LOC(@"ALWAYS_USE_REMAINING_TIME"), LOC(@"ALWAYS_USE_REMAINING_TIME_DESC"), @"alwaysShowRemainingTime_enabled"),
             BASIC_SWITCH(LOC(@"DISABLE_TOGGLE_TIME_REMAINING"), LOC(@"DISABLE_TOGGLE_TIME_REMAINING_DESC"), @"disableRemainingTime_enabled"),
+            BASIC_SWITCH(LOC(@"DISABLE_ENGAGEMENT_OVERLAY"), LOC(@"DISABLE_ENGAGEMENT_OVERLAY_DESC"), @"disableEngagementOverlay_enabled"),
         ];        
         YTSettingsPickerViewController *picker = [[%c(YTSettingsPickerViewController) alloc] initWithNavTitle:LOC(@"VIDEO_CONTROLS_OVERLAY_OPTIONS") pickerSectionTitle:nil rows:rows selectedItemIndex:NSNotFound parentResponder:[self parentResponder]];
         [settingsViewController pushViewController:picker];

--- a/YTLitePlus.xm
+++ b/YTLitePlus.xm
@@ -249,6 +249,14 @@ BOOL isTabSelected = NO;
 %end
 %end
 
+%group gDisableEngagementOverlay
+%hook YTFullscreenEngagementOverlayController
+- (void)setEnabled:(BOOL)enabled {
+    %orig(NO);
+}
+%end
+%end
+
 // YTNoModernUI - @arichornlover
 %group gYTNoModernUI
 %hook YTVersionUtils // YTNoModernUI Original Version
@@ -758,6 +766,9 @@ BOOL isTabSelected = NO;
     }
     if (IsEnabled(@"disablePullToFull_enabled")) {
         %init(gDisablePullToFull);
+    }
+    if (IsEnabled(@"disableEngagementOverlay_enabled")) {
+        %init(gDisableEngagementOverlay);
     }
 
     // Change the default value of some options

--- a/lang/YTLitePlus.bundle/ar.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ar.lproj/Localizable.strings
@@ -41,6 +41,9 @@
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // App settings overlay options
 "APP_SETTINGS_OVERLAY_OPTIONS" = "App Settings Overlay Options";
 

--- a/lang/YTLitePlus.bundle/de.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/de.lproj/Localizable.strings
@@ -41,6 +41,9 @@
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // App settings overlay options
 "APP_SETTINGS_OVERLAY_OPTIONS" = "Overlay-Optionen für App-Einstellungen";
 

--- a/lang/YTLitePlus.bundle/en.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/en.lproj/Localizable.strings
@@ -41,6 +41,9 @@
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // App settings overlay options
 "APP_SETTINGS_OVERLAY_OPTIONS" = "App Settings Overlay Options";
 

--- a/lang/YTLitePlus.bundle/es.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/es.lproj/Localizable.strings
@@ -41,6 +41,9 @@
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // App settings overlay options
 "APP_SETTINGS_OVERLAY_OPTIONS" = "Opciones de superposición de los ajustes de la aplicación";
 

--- a/lang/YTLitePlus.bundle/fr.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/fr.lproj/Localizable.strings
@@ -41,6 +41,9 @@
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // App settings overlay options
 "APP_SETTINGS_OVERLAY_OPTIONS" = "Paramètres des options d'overlay de l'application";
 

--- a/lang/YTLitePlus.bundle/ja.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ja.lproj/Localizable.strings
@@ -41,6 +41,9 @@
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // App settings overlay options
 "APP_SETTINGS_OVERLAY_OPTIONS" = "アプリの設定オーバーレイの設定";
 

--- a/lang/YTLitePlus.bundle/pt.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/pt.lproj/Localizable.strings
@@ -41,6 +41,9 @@
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // App settings overlay options
 "APP_SETTINGS_OVERLAY_OPTIONS" = "App Settings Overlay Options";
 

--- a/lang/YTLitePlus.bundle/ro.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ro.lproj/Localizable.strings
@@ -41,6 +41,9 @@
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // App settings overlay options
 "APP_SETTINGS_OVERLAY_OPTIONS" = "Opțiuni Overlay Setări Aplicație";
 

--- a/lang/YTLitePlus.bundle/ru.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ru.lproj/Localizable.strings
@@ -41,6 +41,9 @@
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // App settings overlay options
 "APP_SETTINGS_OVERLAY_OPTIONS" = "App Settings Overlay Options";
 

--- a/lang/YTLitePlus.bundle/template.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/template.lproj/Localizable.strings
@@ -56,6 +56,9 @@ https://github.com/PoomSmart/Return-YouTube-Dislikes/tree/main/layout/Library/Ap
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // App settings overlay options
 "APP_SETTINGS_OVERLAY_OPTIONS" = "App Settings Overlay Options";
 

--- a/lang/YTLitePlus.bundle/tr.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/tr.lproj/Localizable.strings
@@ -41,6 +41,9 @@
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // App settings overlay options
 "APP_SETTINGS_OVERLAY_OPTIONS" = "App Settings Overlay Options";
 

--- a/lang/YTLitePlus.bundle/vi.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/vi.lproj/Localizable.strings
@@ -50,6 +50,9 @@
 "DISABLE_TOGGLE_TIME_REMAINING" = "Disable toggle time remaining";
 "DISABLE_TOGGLE_TIME_REMAINING_DESC" = "Disables changing time elapsed to time remaining. Use with other setting to always show remaining time.";
 
+"DISABLE_ENGAGEMENT_OVERLAY" = "Disable fullscreen engagement overlay";
+"DISABLE_ENGAGEMENT_OVERLAY_DESC" = "Disable the swipe-up gesture and suggested videos list in fullscreen";
+
 // Shorts controls overlay options
 "SHORTS_CONTROLS_OVERLAY_OPTIONS" = "Tùy chọn lớp phủ điều khiển quần short";
 


### PR DESCRIPTION
Adds a toggle to disable the engagement overlay that can be opened by swiping up on the video player while in fullscreen. This is also the container that shows recommended videos after the video ends. Both of these scenarios are disabled in this tweak.