### PR TITLE
Fix fullscreen to the right

### DIFF
--- a/YTLitePlus.xm
+++ b/YTLitePlus.xm
@@ -249,6 +249,7 @@ BOOL isTabSelected = NO;
 %end
 %end
 
+// Disable fullscreen engagement overlay - @bhackel
 %group gDisableEngagementOverlay
 %hook YTFullscreenEngagementOverlayController
 - (void)setEnabled:(BOOL)enabled {
@@ -439,30 +440,14 @@ BOOL isTabSelected = NO;
 }
 %end
 
-// Fullscreen to the Right (iPhone-exclusive) - @arichornlover
+// Fullscreen to the Right - @arichornlover
 // NOTE: Please turn off the “Portrait Fullscreen” Option in YTLite while the option "Fullscreen to the Right" is enabled below.
 %group gFullscreenToTheRight
 %hook YTWatchViewController
-- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
-    if ([self isFullscreen] && [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-        return UIInterfaceOrientationLandscapeRight;
-    }
-    return %orig;
+- (UIInterfaceOrientationMask)allowedFullScreenOrientations {
+    UIInterfaceOrientationMask orientations = UIInterfaceOrientationMaskLandscapeRight;
+    return orientations;
 }
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    if ([self isFullscreen] && [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-        return UIInterfaceOrientationMaskLandscape;
-    }
-    return %orig;
-}
-%new
-- (void)forceRightFullscreenOrientation {
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-        NSNumber *value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight];
-        [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
-    }
-}
-%end
 %end
 
 // YTTapToSeek - https://github.com/bhackel/YTTapToSeek

--- a/lang/YTLitePlus.bundle/ar.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ar.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/de.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/de.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/en.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/en.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/es.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/es.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/fr.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/fr.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/ja.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ja.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/pt.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/pt.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/ro.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ro.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/ru.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/ru.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/template.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/template.lproj/Localizable.strings
@@ -41,6 +41,9 @@ https://github.com/PoomSmart/Return-YouTube-Dislikes/tree/main/layout/Library/Ap
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/tr.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/tr.lproj/Localizable.strings
@@ -26,6 +26,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/vi.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/vi.lproj/Localizable.strings
@@ -35,6 +35,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 

--- a/lang/YTLitePlus.bundle/zh_TW.lproj/Localizable.strings
+++ b/lang/YTLitePlus.bundle/zh_TW.lproj/Localizable.strings
@@ -27,6 +27,9 @@
 "DISABLE_AMBIENT_FULLSCREEN" = "Disable Ambient Mode (Fullscreen)";
 "DISABLE_AMBIENT_FULLSCREEN_DESC" = "Disable lighting surrouding video player";
 
+"FULLSCREEN_TO_THE_RIGHT" = "Fullscreen to the Right";
+"FULLSCREEN_TO_THE_RIGHT_DESC" = "Always enter fullscreen with home button on the right side.";
+
 "SEEK_ANYWHERE" = "Seek Anywhere Gesture";
 "SEEK_ANYWHERE_DESC" = "Hold and drag on the video player to seek. You must disable YTLite - Hold to speed";
 


### PR DESCRIPTION
Hey @arichornloverALT so it turned out that this feature wasn't actually working, and I was mistaken when I was testing it. However, after some testing, I found the method that the app is using to check for the orientation that should be used. I was wondering why this was originally restricted to iPhone only. I have removed that restriction, but if you have a good reason for it, then I can add it back. Thanks