### PR TITLE
Switch YouPiP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -48,4 +48,4 @@
 	url = https://github.com/PoomSmart/YouTubeHeader.git
 [submodule "Tweaks/YouPiP"]
 	path = Tweaks/YouPiP
-	url = https://github.com/bhackel/YouPiP
+	url = https://github.com/PoomSmart/YouPiP

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "Tweaks/YTUHD"]
 	path = Tweaks/YTUHD
 	url = https://github.com/arichornloverALT/YTUHD.git
-[submodule "Tweaks/YouPiP"]
-	path = Tweaks/YouPiP
-	url = https://github.com/Balackburn/YouPiP.git
 [submodule "Tweaks/Return-YouTube-Dislikes"]
 	path = Tweaks/Return-YouTube-Dislikes
 	url = https://github.com/Balackburn/Return-YouTube-Dislikes.git
@@ -49,3 +46,6 @@
 [submodule "Tweaks/YouTubeHeader"]
 	path = Tweaks/YouTubeHeader
 	url = https://github.com/PoomSmart/YouTubeHeader.git
+[submodule "Tweaks/YouPiP"]
+	path = Tweaks/YouPiP
+	url = https://github.com/bhackel/YouPiP

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ BUNDLE_ID = com.google.ios.youtube
 
 EXTRA_CFLAGS := $(addprefix -I,$(shell find Tweaks/FLEX -name '*.h' -exec dirname {} \;)) -I$(THEOS_PROJECT_DIR)/Tweaks
 
+# Allow YouTubeHeader to be accessible using #include <...>
+export ADDITIONAL_CFLAGS = -I$(THEOS_PROJECT_DIR)/Tweaks
+
 YTLitePlus_INJECT_DYLIBS = Tweaks/YTLite/var/jb/Library/MobileSubstrate/DynamicLibraries/YTLite.dylib .theos/obj/libcolorpicker.dylib .theos/obj/iSponsorBlock.dylib .theos/obj/YTUHD.dylib .theos/obj/YouPiP.dylib .theos/obj/YouTubeDislikesReturn.dylib .theos/obj/YTABConfig.dylib .theos/obj/YouMute.dylib .theos/obj/DontEatMyContent.dylib .theos/obj/YTHoldForSpeed.dylib .theos/obj/YTVideoOverlay.dylib .theos/obj/YouGroupSettings.dylib .theos/obj/YouQuality.dylib
 YTLitePlus_FILES = YTLitePlus.xm $(shell find Source -name '*.xm' -o -name '*.x' -o -name '*.m') $(shell find Tweaks/FLEX -type f \( -iname \*.c -o -iname \*.m -o -iname \*.mm \))
 YTLitePlus_IPA = ./tmp/Payload/YouTube.app


### PR DESCRIPTION
Hello friends, I was wondering what the reason for the fork of YouPiP was for. I think the constant updating of forks causes bugs to stay for longer than needed. However, if there is a good reason for the fork, then I am open to keeping it. If not, then this pull request changes the submodule to PoomSmart's original version. Thanks