### PR TITLE
Fix building on iOS 14

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -140,7 +140,7 @@ jobs:
           sed -i '' "12s#.*#BUNDLE_ID = ${{ env.BUNDLE_ID }}#g" Makefile
           sed -i '' "11s#.*#DISPLAY_NAME = ${{ env.APP_NAME }}#g" Makefile
           sed -i '' "s/^PACKAGE_VERSION.*$/PACKAGE_VERSION = ${{ env.YT_VERSION }}-${{ env.YTLITE_VERSION }}/" Makefile
-          sed -i '' "1s#.*#export TARGET = iphone:clang:${{ inputs.sdk_version }}:15.0#g" Makefile
+          sed -i '' "1s#.*#export TARGET = iphone:clang:${{ inputs.sdk_version }}:14.0#g" Makefile
           make package FINALPACKAGE=1
           (mv "packages/$(ls -t packages | head -n1)" "packages/YTLitePlus_${{ env.YT_VERSION }}_${{ env.YTLITE_VERSION }}.ipa")        
           echo "package=$(ls -t packages | head -n1)" >>$GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGET = iphone:clang:16.5:15.0
+TARGET = iphone:clang:16.5:14.0
 YTLitePlus_USE_FISHHOOK = 0
 ARCHS = arm64
 MODULES = jailed


### PR DESCRIPTION
Support building for iOS 14. Note that the latest supported YouTube version is 19.20. Tested working with both iOS 14.3 and iOS 18b3.

Closes #235 