### PR TITLE
Update catbox.moe urls

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -192,9 +192,9 @@ jobs:
         if: ${{ inputs.catbox_upload }}
         run: |
           RESPONSE=$(curl -F "reqtype=fileupload" -F "fileToUpload=@${{ github.workspace }}/main/packages/${{ steps.build_package.outputs.package }}" https://catbox.moe/user/api.php)
-          CATBOX_URL=$(echo $RESPONSE | grep -o -E 'https://files.catbox.moe/[^"]*')
+          CATBOX_URL=$(echo $RESPONSE | grep -o -E 'https://litter.catbox.moe/[^"]*')
           echo "Uploaded artifact to $CATBOX_URL"
-          CATBOX_FILE=$(echo $CATBOX_URL | sed 's|https://files.catbox.moe/||')
+          CATBOX_FILE=$(echo $CATBOX_URL | sed 's|https://litter.catbox.moe/||')
           # Pass Catbox URL to the release steps
           echo "CATBOX_FILE=$CATBOX_FILE" >> $GITHUB_ENV
           echo "CATBOX_URL=$CATBOX_URL" >> $GITHUB_ENV


### PR DESCRIPTION
`catbox.moe` changed their subdomain for uploaded files: the files uploaded via their Web UI generate a link on the `litter` subdomain. I was also not able to download anything from the `files.catbox.moe` but `litter.catbox.moe` works fine.