### PR TITLE
Fix dlopen/Alderis crash with THEOS_PACKAGE_SCHEME=rootless

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -173,7 +173,7 @@ jobs:
           sed -i '' "s/^PACKAGE_VERSION.*$/PACKAGE_VERSION = ${{ env.YT_VERSION }}-5.0.1/" Makefile
           sed -i '' "s/^export TARGET.*$/export TARGET = iphone:clang:${{ inputs.sdk_version }}:14.0/" Makefile
           # Build the package
-          make package
+          make package THEOS_PACKAGE_SCHEME=rootless
           # Rename the package based on the version
           (mv "packages/$(ls -t packages | head -n1)" "packages/YTLitePlus_${{ env.YT_VERSION }}_5.0.1.ipa")
           # Pass package name to the upload step


### PR DESCRIPTION
This is an important theos variable found in build.sh that is missing from the github build workflow. This fixes all the crash problems such as:

parts of #356 

closes #496 
closes #499 
closes #520 
closes #524

There are some other crashes that this does not fix, but at least the app compiles and opens correctly with this fix!