### PR TITLE
Fix: Update GitHub Actions runner from macos-13 to macos-latest

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -54,7 +54,7 @@ concurrency:
 jobs:
   build:
     name: Build YTLitePlus
-    runs-on: macos-13
+    runs-on: macos-latest
     permissions:
       contents: write
 


### PR DESCRIPTION
The macos-13 runner has been retired by GitHub. This update switches to macos-latest (macOS 15 arm64) which is the current recommended runner.

Resolves the build error related to deprecated macOS runner images.