### PR TITLE
Modify build script to include SIDELOAD option (#611)

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -174,7 +174,7 @@ jobs:
           sed -i '' "s/^export TARGET.*$/export TARGET = iphone:clang:${{ inputs.sdk_version }}:14.0/" Makefile
           sed -i '' "s/^export SDK_PATH.*$/export SDK_PATH = \$(THEOS)\/sdks\/iPhoneOS${{ inputs.sdk_version }}.sdk\//" Makefile
           # Build the package
-          make package THEOS_PACKAGE_SCHEME=rootless FINALPACKAGE=1
+          make package SIDELOAD=1 THEOS_PACKAGE_SCHEME=rootless FINALPACKAGE=1
           # Rename the package based on the version
           (mv "packages/$(ls -t packages | head -n1)" "packages/YTLitePlus_${{ env.YT_VERSION }}_5.0.1.ipa")
           # Pass package name to the upload step


### PR DESCRIPTION
Building with the YTUHD tweak requires libundirect
See: https://github.com/Splaser/YTUHD/commit/a8adbfc

Adding the SIDELOAD=1 flag to the build command addresses build failures
Fixes #683 #681 #611