### PR TITLE
Change default values for catbox_upload and create_release

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -38,12 +38,12 @@ on:
         type: boolean
       catbox_upload:
         description: "Upload iPA to Catbox.moe (URL)"
-        default: true
+        default: false
         required: false
         type: boolean
       create_release:
         description: "Create a draft release (Private)"
-        default: false
+        default: true
         required: false
         type: boolean
 


### PR DESCRIPTION
Since catbox is deafult, the first time users might not see this and might run it and have a failed build. So changed the default value and set to draft release