### PR TITLE
Update action-gh-release to version 2

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Create Draft Release
         if: ${{ inputs.create_release }}
         id: create_release
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Fix intermittent IPA upload failure:
Replace softprops/action-gh-release@v2.2.0 with @v2 to avoid known upload content-length mismatch issues on GitHub runners.