### PR TITLE
fix: authenticate GitHub API calls and prevent redundant Makefile request

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -136,7 +136,7 @@ jobs:
           # Get the version number of the YouTube app and store it
           echo "YT_VERSION=$(grep -A 1 '<key>CFBundleVersion</key>' tmp/Payload/YouTube.app/Info.plist | grep '<string>' | awk -F'[><]' '{print $3}')" >> $GITHUB_ENV
           # Fetch the latest YTLite version from GitHub API
-          YTLITE_VERSION=$(curl -s https://api.github.com/repos/dayanch96/YTLite/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          YTLITE_VERSION=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/dayanch96/YTLite/releases/latest | jq -r '.tag_name' | sed 's/^v//')
           if [ -z "$YTLITE_VERSION" ] || [ "$YTLITE_VERSION" = "null" ]; then
             echo "::error::Failed to fetch latest YTLite version from GitHub API"
             exit 1
@@ -167,6 +167,7 @@ jobs:
         env:
           THEOS: ${{ github.workspace }}/theos
           YOUTUBE_URL: ${{ env.URL_YT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Package
         id: build_package
@@ -178,7 +179,7 @@ jobs:
           sed -i '' "s/^export TARGET.*$/export TARGET = iphone:clang:${{ inputs.sdk_version }}:14.0/" Makefile
           sed -i '' "s/^export SDK_PATH.*$/export SDK_PATH = \$(THEOS)\/sdks\/iPhoneOS${{ inputs.sdk_version }}.sdk\//" Makefile
           # Build the package
-          make package SIDELOAD=1 THEOS_PACKAGE_SCHEME=rootless FINALPACKAGE=1
+          make package SIDELOAD=1 THEOS_PACKAGE_SCHEME=rootless FINALPACKAGE=1 YTLITE_VERSION=${{ env.YTLITE_VERSION }}
           # Rename the package based on the version
           (mv "packages/$(ls -t packages | head -n1)" "packages/YTLitePlus_${{ env.YT_VERSION }}_${{ env.YTLITE_VERSION }}.ipa")
           # Pass package name to the upload step

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ REMOVE_EXTENSIONS = 1
 CODESIGN_IPA = 0
 
 YTLITE_PATH = Tweaks/YTLite
-YTLITE_VERSION := $(shell curl -s https://api.github.com/repos/dayanch96/YTLite/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
+YTLITE_VERSION ?= $(shell curl -s https://api.github.com/repos/dayanch96/YTLite/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
 ifeq ($(YTLITE_VERSION),)
 $(error Failed to fetch latest YTLite version from GitHub API)
 endif


### PR DESCRIPTION
## Problem

The `curl` calls to the GitHub API in both the workflow step and the Makefile were unauthenticated, and returned empty on the GitHub Actions runner, causing the build to fail with `Failed to fetch latest YTLite version from GitHub API`. Adding `GITHUB_TOKEN` authentication resolved this.

## Changes

**`buildapp.yml`** — Authenticate the API `curl` call:
https://github.com/YTLitePlus/YTLitePlus/blob/main/.github/workflows/buildapp.yml#L139

**`buildapp.yml`** — Expose `GITHUB_TOKEN` in the step's `env` block:
https://github.com/YTLitePlus/YTLitePlus/blob/main/.github/workflows/buildapp.yml#L167-L170

**`buildapp.yml`** — Pass `YTLITE_VERSION` explicitly to `make` to avoid a redundant API call from the Makefile:
https://github.com/YTLitePlus/YTLitePlus/blob/main/.github/workflows/buildapp.yml#L181

**`Makefile`** — Changed `:=` to `?=` so the fallback `curl` is skipped when the version is already provided:
https://github.com/YTLitePlus/YTLitePlus/blob/main/Makefile#L49
